### PR TITLE
fixup! Make transfer props available to users

### DIFF
--- a/src/components/Alert/README.md
+++ b/src/components/Alert/README.md
@@ -176,13 +176,14 @@ with the API of the React component are forwarded to the root `<div>` HTML
 element. This enables making the component interactive and helps to improve
 its accessibility.
 
-👉 For forwarding HTML attributes programmatically, you can use the `transferProps` function. For detailed usage examples, refer to the [TransferProps documentation](/src/docs/js-helpers/transferProps.md).
+👉 For forwarding HTML attributes programmatically, you can use the
+`transferProps` function. For detailed usage examples, refer to the
+[TransferProps documentation](/src/docs/js-helpers/transferProps.md).
 
 For the full list of supported attributes, you can also refer to:
 
 - [`<div>` HTML element attributes][div-attributes]{:target="_blank"}
 - [React common props]{:target="_blank"}
-
 
 ## API
 


### PR DESCRIPTION
This is an example how to solve the formatting issue.

I only did it on `src/components/Alert/README.md` but I believe the same solution can be used on other files as well.